### PR TITLE
Organise dexec sources better #23

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -1,5 +1,6 @@
 {
-    "PackageVersion": "1.0.1",
+    "PackageVersion": "1.0.2",
+    "PrereleaseInfo": "snapshot",
     "ConfigVersion": "0.9",
     "TaskSettings": {
         "bintray": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Changed
+- Moved Docker and CLI related functionality to separate packages.
 
 ## [1.0.1] - 2015-04-20
 ### Added

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -51,8 +51,8 @@ const (
 // CLI defines a data structure that represents the application's name and
 // a map of the various options to be used when starting the container.
 type CLI struct {
-	filename string
-	options  map[OptionType][]string
+	Filename string
+	Options  map[OptionType][]string
 }
 
 // ArgToOption takes two candidate strings and returns a tuple consisting of
@@ -134,8 +134,8 @@ func ParseArgs(args []string) map[OptionType][]string {
 // filename and map of option types to their values.
 func ParseOsArgs(args []string) CLI {
 	return CLI{
-		filename: args[0],
-		options:  ParseArgs(args[1:]),
+		Filename: args[0],
+		Options:  ParseArgs(args[1:]),
 	}
 }
 
@@ -161,5 +161,5 @@ func DisplayHelp(filename string) {
 
 // DisplayVersion prints the version information for the program.
 func DisplayVersion(filename string) {
-	fmt.Printf("%s 1.0.1\n", filename)
+	fmt.Printf("%s 1.0.2-snapshot\n", filename)
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"reflect"
@@ -137,8 +137,8 @@ func TestFilename(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if got.filename != c.want {
-			t.Errorf("ParseOsArgs %q != %q", got.filename, c.want)
+		if got.Filename != c.want {
+			t.Errorf("ParseOsArgs %q != %q", got.Filename, c.want)
 		}
 	}
 }
@@ -152,8 +152,8 @@ func TestTargetDir(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[TargetDir], c.want) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[TargetDir], c.want)
+		if !reflect.DeepEqual(got.Options[TargetDir], c.want) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[TargetDir], c.want)
 		}
 	}
 }
@@ -170,8 +170,8 @@ func TestSources(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[Source], c.want) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[Source], c.want)
+		if !reflect.DeepEqual(got.Options[Source], c.want) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[Source], c.want)
 		}
 	}
 }
@@ -188,8 +188,8 @@ func TestSpecifyImage(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[SpecifyImage], c.want) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[SpecifyImage], c.want)
+		if !reflect.DeepEqual(got.Options[SpecifyImage], c.want) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[SpecifyImage], c.want)
 		}
 	}
 }
@@ -206,8 +206,8 @@ func TestIncludes(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[Include], c.want) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[Include], c.want)
+		if !reflect.DeepEqual(got.Options[Include], c.want) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[Include], c.want)
 		}
 	}
 }
@@ -224,8 +224,8 @@ func TestArgs(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[Arg], c.want) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[Arg], c.want)
+		if !reflect.DeepEqual(got.Options[Arg], c.want) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[Arg], c.want)
 		}
 	}
 }
@@ -242,8 +242,8 @@ func TestBuildArgs(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[BuildArg], c.want) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[BuildArg], c.want)
+		if !reflect.DeepEqual(got.Options[BuildArg], c.want) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[BuildArg], c.want)
 		}
 	}
 }
@@ -299,12 +299,12 @@ func TestOrdering(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := ParseOsArgs(c.osArgs)
-		if !reflect.DeepEqual(got.options[BuildArg], c.want[BuildArg]) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[BuildArg], c.want[BuildArg])
-		} else if !reflect.DeepEqual(got.options[Arg], c.want[Arg]) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[Arg], c.want[Arg])
-		} else if !reflect.DeepEqual(got.options[Source], c.want[Source]) {
-			t.Errorf("ParseOsArgs %q != %q", got.options[Source], c.want[Source])
+		if !reflect.DeepEqual(got.Options[BuildArg], c.want[BuildArg]) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[BuildArg], c.want[BuildArg])
+		} else if !reflect.DeepEqual(got.Options[Arg], c.want[Arg]) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[Arg], c.want[Arg])
+		} else if !reflect.DeepEqual(got.Options[Source], c.want[Source]) {
+			t.Errorf("ParseOsArgs %q != %q", got.Options[Source], c.want[Source])
 		}
 	}
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"os"

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"reflect"


### PR DESCRIPTION
Create packages for 'cli' and 'docker' functions. These are still
heavily coupled to dexec, but it's a start.

Also bumped version to 1.0.2-snapshot.