### PR TITLE
Decouple string & path utilities from dexec #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 ### Changed
-- Moved Docker and CLI related functionality to separate packages.
+- Moved Docker, CLI & miscellaneous functionality to separate packages.
 
 ## [1.0.1] - 2015-04-20
 ### Added

--- a/dexec.go
+++ b/dexec.go
@@ -11,19 +11,8 @@ import (
 
 	"github.com/docker-exec/dexec/cli"
 	"github.com/docker-exec/dexec/docker"
+	"github.com/docker-exec/dexec/util"
 )
-
-// ExtractFileExtension extracts the extension from a filename. This is defined
-// as the remainder of the string after the last '.'.
-func ExtractFileExtension(filename string) string {
-	patternPermission := regexp.MustCompile(`.*\.(.*):.*`)
-	permissionMatch := patternPermission.FindStringSubmatch(filename)
-	if len(permissionMatch) > 0 {
-		return permissionMatch[1]
-	}
-	patternFilename := regexp.MustCompile(`.*\.(.*)`)
-	return patternFilename.FindStringSubmatch(filename)[1]
-}
 
 // DexecImage consists of the file extension, Docker image name and Docker
 // image version to use for a given Docker Exec image.
@@ -179,10 +168,10 @@ func RunDexecContainer(dexecImage DexecImage, options map[cli.OptionType][]strin
 		sourceBasenames = append(sourceBasenames, []string{basename}...)
 	}
 
-	entrypointArgs := docker.JoinStringSlices(
+	entrypointArgs := util.JoinStringSlices(
 		sourceBasenames,
-		docker.AddPrefix(options[cli.BuildArg], "-b"),
-		docker.AddPrefix(options[cli.Arg], "-a"),
+		util.AddPrefix(options[cli.BuildArg], "-b"),
+		util.AddPrefix(options[cli.Arg], "-a"),
 	)
 
 	if len(options[cli.UpdateFlag]) > 0 {
@@ -221,7 +210,7 @@ func main() {
 	cliParser := cli.ParseOsArgs(os.Args)
 
 	if validate(cliParser) {
-		extension := ExtractFileExtension(cliParser.Options[cli.Source][0])
+		extension := util.ExtractFileExtension(cliParser.Options[cli.Source][0])
 		image := LookupImageByExtension(extension)
 		if len(cliParser.Options[cli.SpecifyImage]) == 1 {
 			image = LookupImageByOverride(cliParser.Options[cli.SpecifyImage][0], extension)

--- a/dexec_test.go
+++ b/dexec_test.go
@@ -39,22 +39,6 @@ func TestSanitisePath(t *testing.T) {
 	}
 }
 
-func TestExtractFileExtension(t *testing.T) {
-	cases := []struct {
-		filename  string
-		extension string
-	}{
-		{"foo.bar", "bar"},
-		{"foo.bar.foobar", "foobar"},
-	}
-	for _, c := range cases {
-		gotExtension := ExtractFileExtension(c.filename)
-		if gotExtension != c.extension {
-			t.Errorf("ExtractFileExtension %q != %q", gotExtension, c.extension)
-		}
-	}
-}
-
 func TestLookupImageByOverride(t *testing.T) {
 	cases := []struct {
 		image         string

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -5,28 +5,9 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+
+	"github.com/docker-exec/dexec/util"
 )
-
-// AddPrefix takes a string slice and returns a new string slice
-// with the supplied prefix inserted before every string in the
-// original slice.
-func AddPrefix(inSlice []string, prefix string) []string {
-	var outSlice []string
-	for _, option := range inSlice {
-		outSlice = append(outSlice, []string{prefix, option}...)
-	}
-	return outSlice
-}
-
-// JoinStringSlices takes an arbitrary number of string slices
-// and concatenates them in the order supplied.
-func JoinStringSlices(slices ...[]string) []string {
-	var outSlice []string
-	for _, slice := range slices {
-		outSlice = append(outSlice, slice...)
-	}
-	return outSlice
-}
 
 // DockerVersion shells out the command 'docker -v', returning the version
 // information if the command is successful, and panicking if not.
@@ -115,7 +96,7 @@ func RunAnonymousContainer(image string, extraDockerArgs []string, entrypointArg
 	imageDockerArgs := []string{"-t", image}
 	out := exec.Command(
 		"docker",
-		JoinStringSlices(
+		util.JoinStringSlices(
 			baseDockerArgs,
 			extraDockerArgs,
 			imageDockerArgs,

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -31,44 +31,6 @@ func Patch(dest, value interface{}) Restorer {
 	}
 }
 
-func TestAddPrefix(t *testing.T) {
-	cases := []struct {
-		inSlice []string
-		prefix  string
-		want    []string
-	}{
-		{
-			[]string{"foo", "bar", "foobar"},
-			"prefix",
-			[]string{"prefix", "foo", "prefix", "bar", "prefix", "foobar"},
-		},
-	}
-	for _, c := range cases {
-		got := AddPrefix(c.inSlice, c.prefix)
-		if !reflect.DeepEqual(got, c.want) {
-			t.Errorf("AddPrefix(%q, %q) %q != %q", c.inSlice, c.prefix, got, c.want)
-		}
-	}
-}
-
-func TestJoinStringSlices(t *testing.T) {
-	cases := []struct {
-		inSlices [][]string
-		want     []string
-	}{
-		{
-			[][]string{{"foo"}, {"bar"}, {"foobar"}},
-			[]string{"foo", "bar", "foobar"},
-		},
-	}
-	for _, c := range cases {
-		got := JoinStringSlices(c.inSlices...)
-		if !reflect.DeepEqual(got, c.want) {
-			t.Errorf("JoinStringSlices(%q) %q != %q", c.inSlices, got, c.want)
-		}
-	}
-}
-
 func TestExtractDockerVersion(t *testing.T) {
 	cases := []struct {
 		version string

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,36 @@
+package util
+
+import "regexp"
+
+// AddPrefix takes a string slice and returns a new string slice
+// with the supplied prefix inserted before every string in the
+// original slice.
+func AddPrefix(inSlice []string, prefix string) []string {
+	var outSlice []string
+	for _, option := range inSlice {
+		outSlice = append(outSlice, []string{prefix, option}...)
+	}
+	return outSlice
+}
+
+// JoinStringSlices takes an arbitrary number of string slices
+// and concatenates them in the order supplied.
+func JoinStringSlices(slices ...[]string) []string {
+	var outSlice []string
+	for _, slice := range slices {
+		outSlice = append(outSlice, slice...)
+	}
+	return outSlice
+}
+
+// ExtractFileExtension extracts the extension from a filename. This is defined
+// as the remainder of the string after the last '.'.
+func ExtractFileExtension(filename string) string {
+	patternPermission := regexp.MustCompile(`.*\.(.*):.*`)
+	permissionMatch := patternPermission.FindStringSubmatch(filename)
+	if len(permissionMatch) > 0 {
+		return permissionMatch[1]
+	}
+	patternFilename := regexp.MustCompile(`.*\.(.*)`)
+	return patternFilename.FindStringSubmatch(filename)[1]
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAddPrefix(t *testing.T) {
+	cases := []struct {
+		inSlice []string
+		prefix  string
+		want    []string
+	}{
+		{
+			[]string{"foo", "bar", "foobar"},
+			"prefix",
+			[]string{"prefix", "foo", "prefix", "bar", "prefix", "foobar"},
+		},
+	}
+	for _, c := range cases {
+		got := AddPrefix(c.inSlice, c.prefix)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("AddPrefix(%q, %q) %q != %q", c.inSlice, c.prefix, got, c.want)
+		}
+	}
+}
+
+func TestJoinStringSlices(t *testing.T) {
+	cases := []struct {
+		inSlices [][]string
+		want     []string
+	}{
+		{
+			[][]string{{"foo"}, {"bar"}, {"foobar"}},
+			[]string{"foo", "bar", "foobar"},
+		},
+	}
+	for _, c := range cases {
+		got := JoinStringSlices(c.inSlices...)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("JoinStringSlices(%q) %q != %q", c.inSlices, got, c.want)
+		}
+	}
+}
+
+func TestExtractFileExtension(t *testing.T) {
+	cases := []struct {
+		filename  string
+		extension string
+	}{
+		{"foo.bar", "bar"},
+		{"foo.bar.foobar", "foobar"},
+	}
+	for _, c := range cases {
+		gotExtension := ExtractFileExtension(c.filename)
+		if gotExtension != c.extension {
+			t.Errorf("ExtractFileExtension %q != %q", gotExtension, c.extension)
+		}
+	}
+}


### PR DESCRIPTION
Moved the following out of dexec.go into new util package:
 * AddPrefix
 * JoinStringSlices
 * ExtractFileExtension