### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ $ dexec --clean
 The shebang is stripped out at execution time but the original source containing the shebang is preserved.
 
 ```c++
-#!/usr/bin/env dexec
-#include <iostream>
+# !/usr/bin/env dexec
+# include <iostream>
 int main() {
     std::cout << "hello world" << std::endl;
 }


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
